### PR TITLE
Feature/crash fix and Prepare release 1.1.0

### DIFF
--- a/BitmovinAdobeAnalytics.podspec
+++ b/BitmovinAdobeAnalytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'BitmovinAdobeAnalytics'
-  s.version          = '1.0.0-rc1'
+  s.version          = '1.1.0'
   s.summary          = 'Adobe Analytics Integration for the Bitmovin Player iOS SDK'
 
   s.description      = <<-DESC

--- a/BitmovinAdobeAnalytics/Assets/BitmovinAdobe-Info.plist
+++ b/BitmovinAdobeAnalytics/Assets/BitmovinAdobe-Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0-rc1</string>
+	<string>1.1.0</string>
 </dict>
 </plist>

--- a/BitmovinAdobeAnalytics/README.md
+++ b/BitmovinAdobeAnalytics/README.md
@@ -17,7 +17,7 @@ This module allows for the integration of your Adobe Experience Media Analytics 
 - To install it, simply add it as a dependency to your project. Add the following pod to your Podfile:
 
 ```
-pod 'BitmovinAdobeAnalytics', git: 'https://github.com/bitmovin/bitmovin-player-ios-analytics-adobe.git', tag: '1.0.0-rc1'
+pod 'BitmovinAdobeAnalytics', git: 'https://github.com/bitmovin/bitmovin-player-ios-analytics-adobe.git', tag: '1.1.0'
 ```
 
 2. Add Adobe Media Analytics to your application. Please refer to [Adobe documentation](https://aep-sdks.gitbook.io/docs/using-mobile-extensions/adobe-media-analytics#add-media-analytics-to-your-app)

--- a/BitmovinAdobeAnalytics/Sources/BitmovinAdobeAnalytics/AdobeMediaAnalytics.swift
+++ b/BitmovinAdobeAnalytics/Sources/BitmovinAdobeAnalytics/AdobeMediaAnalytics.swift
@@ -51,11 +51,14 @@ public final class AdobeMediaAnalytics: NSObject {
     public init?(player: Player,
                  config: AdobeConfiguration = AdobeConfiguration(),
                  delegate: AdobeAnalyticsDataOverrideDelegate?) throws {
+        self.mediaTracker = ACPMedia.createTracker()
+        if self.mediaTracker == nil {
+            return nil;
+        }
+
         self.player = player
         self.config = config
-
         self.logger = Logger(loggingEnabled: config.debugLoggingEnabled)
-        self.mediaTracker = ACPMedia.createTracker()!
         self.dataOverrideDelegate = delegate
         self.listener = BitmovinPlayerListener(player: player)
         

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial implementation
 
-[1.0.0]: https://github.com/bitmovin/bitmovin-player-ios-analytics-adobe/commit/100dc3f81f971c28cd2b2c2868d2c71cbb501e5e
+## [1.1.0] (2020-03-18)
+
+### Fixed
+- Fixed crash issue if `ACPMedia.createTracker()` returns `nil` and AdobeMediaAnalytics cannot be instantiated
+
+[1.0.0]: https://github.com/bitmovin/bitmovin-player-ios-analytics-adobe/releases/tag/1.0.0
+[1.1.0]: https://github.com/bitmovin/bitmovin-player-ios-analytics-adobe/releases/tag/1.1.0
+


### PR DESCRIPTION
**Issue**

If `ACPMedia.createTracker()` fails to create, it leads to crash as the AdobeAnalytics object is still created forcing use of the underlying tracker object

**Fix**

fail to create `AdobeMediaAnalytics` object and return `nil` if `ACPMedia.createTracker()` fails. Application should check if `AdobeMediaAnalytics` failed and returned `nil`. In this case the Adobe analytics events will not be captured for playback session but as the underlying Adobe tracker failed to instantiate, there is not much else that can be done.

