### PR TITLE
Upgrade Adobe integration to be compatible with V3 version of Bitmovin iOS Player SDK

### DIFF
--- a/BitmovinAdobeAnalytics.podspec
+++ b/BitmovinAdobeAnalytics.podspec
@@ -18,7 +18,7 @@ Adobe Analytics Integration for the Bitmovin Player iOS SDK
   s.source_files = 'BitmovinAdobeAnalytics/Sources/**/*.swift'
   s.resources = 'BitmovinAdobeAnalytics/Assets/*'
   s.swift_version = '5.2'
-  s.cocoapods_version = '>= 1.4.0'
+  s.cocoapods_version = '>= 1.9.0'
 
   s.ios.dependency 'BitmovinPlayer', '~> 3.0'
   s.ios.dependency 'ACPCore', '~> 2.0'

--- a/BitmovinAdobeAnalytics.podspec
+++ b/BitmovinAdobeAnalytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'BitmovinAdobeAnalytics'
-  s.version          = '1.2.0'
+  s.version          = '2.0.0'
   s.summary          = 'Adobe Analytics Integration for the Bitmovin Player iOS SDK'
 
   s.description      = <<-DESC
@@ -12,19 +12,19 @@ Adobe Analytics Integration for the Bitmovin Player iOS SDK
   s.author           = { 'Bitmovin' => 'lucky.goyal@bitmovin.com' }
   s.source           = { git: 'https://github.com/bitmovin/bitmovin-player-ios-analytics-adobe.git', tag: s.version.to_s }
   #s.source           = { git: '' }
-  s.ios.deployment_target = '10.0'
-  s.tvos.deployment_target = '10.0'
+  s.ios.deployment_target = '12.0'
+  s.tvos.deployment_target = '12.0'
 
   s.source_files = 'BitmovinAdobeAnalytics/Sources/**/*.swift'
   s.resources = 'BitmovinAdobeAnalytics/Assets/*'
   s.swift_version = '5.2'
   s.cocoapods_version = '>= 1.4.0'
 
-  s.ios.dependency 'BitmovinPlayer', '~> 2.57'
+  s.ios.dependency 'BitmovinPlayer', '~> 3.0'
   s.ios.dependency 'ACPCore', '~> 2.0'
   s.ios.dependency 'ACPAnalytics', '~> 2.0'
   s.ios.dependency 'ACPMedia', '~> 2.0'
-  s.tvos.dependency 'BitmovinPlayer', '~> 2.57'
+  s.tvos.dependency 'BitmovinPlayer', '~> 3.0'
   s.tvos.dependency 'ACPCore', '~> 2.0'
   s.tvos.dependency 'ACPAnalytics', '~> 2.0'
   s.tvos.dependency 'ACPMedia', '~> 2.0'

--- a/BitmovinAdobeAnalytics/Assets/BitmovinAdobe-Info.plist
+++ b/BitmovinAdobeAnalytics/Assets/BitmovinAdobe-Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>2.0.0</string>
 </dict>
 </plist>

--- a/BitmovinAdobeAnalytics/Package.swift
+++ b/BitmovinAdobeAnalytics/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "BitmovinAdobeAnalytics",
     platforms: [
-        .iOS(.v10), .tvOS(.v10)
+        .iOS(.v12), .tvOS(.v12)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/BitmovinAdobeAnalytics/README.md
+++ b/BitmovinAdobeAnalytics/README.md
@@ -12,7 +12,7 @@ This module allows for the integration of your Adobe Experience Media Analytics 
 
 ### Installation & Configuration
 
-1. `BitmovinAdobeAnalytics` is available through [CocoaPods](https://cocoapods.org). We depend on cocoapods version >= 1.4.
+1. `BitmovinAdobeAnalytics` is available through [CocoaPods](https://cocoapods.org). We depend on cocoapods version >= 1.9.0
 
 - To install it, simply add it as a dependency to your project. Add the following pod to your Podfile:
 

--- a/BitmovinAdobeAnalytics/README.md
+++ b/BitmovinAdobeAnalytics/README.md
@@ -17,7 +17,7 @@ This module allows for the integration of your Adobe Experience Media Analytics 
 - To install it, simply add it as a dependency to your project. Add the following pod to your Podfile:
 
 ```
-pod 'BitmovinAdobeAnalytics', git: 'https://github.com/bitmovin/bitmovin-player-ios-analytics-adobe.git', tag: '1.2.0'
+pod 'BitmovinAdobeAnalytics', git: 'https://github.com/bitmovin/bitmovin-player-ios-analytics-adobe.git', tag: '2.0.0'
 ```
 
 2. Add Adobe Media Analytics to your application. Please refer to [Adobe documentation](https://aep-sdks.gitbook.io/docs/using-mobile-extensions/adobe-media-analytics#add-media-analytics-to-your-app)
@@ -72,7 +72,8 @@ func application(_ application: UIApplication,
 `your-launch-app-id` : ApplicationId setup following steps [here](https://aep-sdks.gitbook.io/docs/using-mobile-extensions/mobile-core/configuration)
 
 ### Compatibility
-This version of the Adobe Analytics Integration is validated with `BitmovinPlayer` version `>= 2.57.x`. It should work with older versions as well but is subject to validation.
+Versions 2.x.x of this Adobe analytics integration is comaptible with `BitmovinPlayer` version `>= 3.0.0`.
+Versions 1.x.x of this Adobe analytics integration is compatible with `BitmovinPlayer` version `< 3.0.0`. These are validated with player version `>= 2.57.x`.
 
 ## Usage
 ----------------

--- a/BitmovinAdobeAnalytics/Sources/BitmovinAdobeAnalytics/AdobeMediaAnalytics.swift
+++ b/BitmovinAdobeAnalytics/Sources/BitmovinAdobeAnalytics/AdobeMediaAnalytics.swift
@@ -31,7 +31,7 @@ public final class AdobeMediaAnalytics: NSObject {
     /**
      Set the BMPBitmovinPlayerView to enable view triggered events like fullscreen state changes
      */
-    public var playerView: BMPBitmovinPlayerView? {
+    public var playerView: PlayerView? {
         didSet {
             playerView?.remove(listener: self)
             playerView?.add(listener: self)
@@ -114,7 +114,7 @@ public final class AdobeMediaAnalytics: NSObject {
 // MARK: - PlayerListener
 extension AdobeMediaAnalytics: BitmovinPlayerListenerDelegate {
     
-    func onEvent(_ event: PlayerEvent) {
+    func onEvent(_ event: Event) {
         logger.debugLog(message: "[ Player Event ] \(event.name)")
     }
 
@@ -127,7 +127,16 @@ extension AdobeMediaAnalytics: BitmovinPlayerListenerDelegate {
         mediaTracker.updateCurrentPlayhead(event.currentTime)
     }
 
-    func onError(_ event: ErrorEvent) {
+    func onPlayerError(_ event: PlayerErrorEvent) {
+        if !isSessionActive {
+            internalInitializeSession()
+        }
+
+        let message = "\(event.code) \(event.message)"
+        mediaTracker.trackError(message)
+    }
+    
+    func onSourceError(_ event: SourceErrorEvent) {
         if !isSessionActive {
             internalInitializeSession()
         }
@@ -296,11 +305,11 @@ extension AdobeMediaAnalytics: AdobeAnalyticsDataOverrideDelegate {
         return nil
     }
 
-    public func getMediaName (_ player: Player, _ source: SourceItem) -> String {
+    public func getMediaName (_ player: Player, _ source: Source) -> String {
         return "default_Media_Name"
     }
 
-    public func getMediaId (_ player: Player, _ source: SourceItem) -> String {
+    public func getMediaId (_ player: Player, _ source: Source) -> String {
         return "default_Media_ID"
     }
     

--- a/BitmovinAdobeAnalytics/Sources/BitmovinAdobeAnalytics/AdobeMediaAnalyticsDataDelegate.swift
+++ b/BitmovinAdobeAnalytics/Sources/BitmovinAdobeAnalytics/AdobeMediaAnalyticsDataDelegate.swift
@@ -12,9 +12,9 @@ public protocol AdobeAnalyticsDataOverrideDelegate: AnyObject {
 
     func getMediaContextData (_ player: Player) -> NSMutableDictionary?
 
-    func getMediaName (_ player: Player, _ source: SourceItem) -> String
+    func getMediaName (_ player: Player, _ source: Source) -> String
 
-    func getMediaId (_ player: Player, _ source: SourceItem) -> String
+    func getMediaId (_ player: Player, _ source: Source) -> String
 
     func getAdBreakId (_ player: Player, _ event: AdBreakStartedEvent) -> String
 

--- a/BitmovinAdobeAnalytics/Sources/BitmovinAdobeAnalytics/BitmovinPlayerListener.swift
+++ b/BitmovinAdobeAnalytics/Sources/BitmovinAdobeAnalytics/BitmovinPlayerListener.swift
@@ -24,11 +24,11 @@ class BitmovinPlayerListener: NSObject {
 }
 
 extension BitmovinPlayerListener: PlayerListener {
-    func onEvent(_ event: PlayerEvent) {
+    func onEvent(_ event: Event, player: Player) {
         delegate?.onEvent(event)
     }
 
-    func onSourceUnloaded(_ event: SourceUnloadedEvent) {
+    func onSourceUnloaded(_ event: SourceUnloadedEvent, player: Player) {
         // The default SDK error handling is that it triggers the onSourceUnloaded before the onError event.
         // To track errors to Adobe we need to delay the onSourceUnloaded to ensure the onError event is called first.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
@@ -36,96 +36,100 @@ extension BitmovinPlayerListener: PlayerListener {
         }
     }
 
-    func onTimeChanged(_ event: TimeChangedEvent) {
+    func onTimeChanged(_ event: TimeChangedEvent, player: Player) {
         delegate?.onTimeChanged(event)
     }
 
-    func onError(_ event: ErrorEvent) {
-        delegate?.onError(event)
+    func onPlayerError(_ event: PlayerErrorEvent, player: Player) {
+        delegate?.onPlayerError(event)
+    }
+    
+    func onSourceError(_ event: SourceErrorEvent, player: Player) {
+        delegate?.onSourceError(event)
     }
 
-    func onMuted(_ event: MutedEvent) {
+    func onMuted(_ event: MutedEvent, player: Player) {
         delegate?.onMuted(event)
     }
 
-    func onUnmuted(_ event: UnmutedEvent) {
+    func onUnmuted(_ event: UnmutedEvent, player: Player) {
         delegate?.onUnmuted(event)
     }
 
     // MARK: - Playback state events
-    func onPlay(_ event: PlayEvent) {
+    func onPlay(_ event: PlayEvent, player: Player) {
         delegate?.onPlay()
     }
 
-    func onPlaying(_ event: PlayingEvent) {
+    func onPlaying(_ event: PlayingEvent, player: Player) {
         delegate?.onPlaying()
     }
 
-    func onPaused(_ event: PausedEvent) {
+    func onPaused(_ event: PausedEvent, player: Player) {
         delegate?.onPaused()
     }
 
-    func onPlaybackFinished(_ event: PlaybackFinishedEvent) {
+    func onPlaybackFinished(_ event: PlaybackFinishedEvent, player: Player) {
         delegate?.onPlaybackFinished()
     }
 
-    func onStallStarted(_ event: StallStartedEvent) {
+    func onStallStarted(_ event: StallStartedEvent, player: Player) {
         delegate?.onStallStarted()
     }
 
-    func onStallEnded(_ event: StallEndedEvent) {
+    func onStallEnded(_ event: StallEndedEvent, player: Player) {
         delegate?.onStallEnded()
     }
 
     // MARK: - Seek / Timeshift events
-    func onSeek(_ event: SeekEvent) {
+    func onSeek(_ event: SeekEvent, player: Player) {
         delegate?.onSeek(event)
     }
 
-    func onSeeked(_ event: SeekedEvent) {
+    func onSeeked(_ event: SeekedEvent, player: Player) {
         delegate?.onSeeked()
     }
 
-    func onTimeShift(_ event: TimeShiftEvent) {
+    func onTimeShift(_ event: TimeShiftEvent, player: Player) {
         delegate?.onTimeShift(event)
     }
 
-    func onTimeShifted(_ event: TimeShiftedEvent) {
+    func onTimeShifted(_ event: TimeShiftedEvent, player: Player) {
         delegate?.onTimeShifted()
     }
     
-    func onVideoDownloadQualityChanged(_ event: VideoDownloadQualityChangedEvent) {
+    func onVideoDownloadQualityChanged(_ event: VideoDownloadQualityChangedEvent, player: Player) {
         delegate?.onVideoQualityChanged(event)
     }
 
     #if !os(tvOS)
     // MARK: - Ad events
-    func onAdBreakStarted(_ event: AdBreakStartedEvent) {
+    func onAdBreakStarted(_ event: AdBreakStartedEvent, player: Player) {
         delegate?.onAdBreakStarted(event)
     }
     
-    func onAdBreakFinished(_ event: AdBreakFinishedEvent) {
+    func onAdBreakFinished(_ event: AdBreakFinishedEvent, player: Player) {
         delegate?.onAdBreakFinished(event)
     }
     
-    func onAdStarted(_ event: AdStartedEvent) {
+    func onAdStarted(_ event: AdStartedEvent, player: Player) {
         delegate?.onAdStarted(event)
     }
 
-    func onAdFinished(_ event: AdFinishedEvent) {
+    func onAdFinished(_ event: AdFinishedEvent, player: Player) {
         delegate?.onAdFinished(event)
     }
 
-    func onAdSkipped(_ event: AdSkippedEvent) {
+    func onAdSkipped(_ event: AdSkippedEvent, player: Player) {
         delegate?.onAdSkipped(event)
     }
 
-    func onAdError(_ event: AdErrorEvent) {
+    func onAdError(_ event: AdErrorEvent, player: Player) {
         delegate?.onAdError(event)
     }
     #endif
 
-    func onDestroy(_ event: DestroyEvent) {
+    func onDestroy(_ event: DestroyEvent, player: Player) {
         delegate?.onDestroy()
     }
 }

--- a/BitmovinAdobeAnalytics/Sources/BitmovinAdobeAnalytics/BitmovinPlayerListenerDelegate.swift
+++ b/BitmovinAdobeAnalytics/Sources/BitmovinAdobeAnalytics/BitmovinPlayerListenerDelegate.swift
@@ -9,10 +9,11 @@ import Foundation
 import BitmovinPlayer
 
 protocol BitmovinPlayerListenerDelegate: AnyObject {
-    func onEvent(_ event: PlayerEvent)
+    func onEvent(_ event: Event)
     func onSourceUnloaded()
     func onTimeChanged(_ event: TimeChangedEvent)
-    func onError(_ event: ErrorEvent)
+    func onPlayerError(_ event: PlayerErrorEvent)
+    func onSourceError(_ event: SourceErrorEvent)
 
     func onMuted(_ event: MutedEvent)
     func onUnmuted(_ event: UnmutedEvent)

--- a/Example/BitmovinAdobeAnalytics.xcodeproj/project.pbxproj
+++ b/Example/BitmovinAdobeAnalytics.xcodeproj/project.pbxproj
@@ -439,13 +439,13 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-BitmovinAdobeAnalytics_Example/Pods-BitmovinAdobeAnalytics_Example-frameworks.sh",
-				"${PODS_ROOT}/BitmovinPlayer/iOS/BitmovinPlayer.framework",
 				"${PODS_ROOT}/GoogleAds-IMA-iOS-SDK/GoogleInteractiveMediaAds.framework",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/BitmovinPlayer/BitmovinPlayer.framework/BitmovinPlayer",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BitmovinPlayer.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleInteractiveMediaAds.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BitmovinPlayer.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -499,15 +499,15 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-BitmovinAdobeAnalytics_Tests/Pods-BitmovinAdobeAnalytics_Tests-frameworks.sh",
-				"${PODS_ROOT}/BitmovinPlayer/iOS/BitmovinPlayer.framework",
 				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
 				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/BitmovinPlayer/BitmovinPlayer.framework/BitmovinPlayer",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BitmovinPlayer.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BitmovinPlayer.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -539,7 +539,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-BitmovinAdobeAnalytics_TvOSExample/Pods-BitmovinAdobeAnalytics_TvOSExample-frameworks.sh",
-				"${PODS_ROOT}/BitmovinPlayer/tvOS/BitmovinPlayer.framework",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/BitmovinPlayer/BitmovinPlayer.framework/BitmovinPlayer",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -649,7 +649,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Debug;
 		};
@@ -683,7 +683,7 @@
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Release;
 		};
@@ -732,7 +732,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -778,7 +778,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -793,7 +793,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = 7UXPEM3WRB;
 				INFOPLIST_FILE = BitmovinAdobeAnalytics/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bitmovin.analytics.adobe.example;
@@ -809,7 +809,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = 7UXPEM3WRB;
 				INFOPLIST_FILE = BitmovinAdobeAnalytics/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bitmovin.analytics.adobe.example;

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,8 +1,9 @@
-source 'https://cdn.cocoapods.org'
 source 'https://github.com/bitmovin/cocoapod-specs.git'
+source 'https://github.com/CocoaPods/Specs.git'
+
 def shared_pods
   pod 'BitmovinAdobeAnalytics', path: '../'
-  pod 'BitmovinPlayer', '2.57.0'
+  pod 'BitmovinPlayer', '3.6.0'
   pod 'ACPCore', '~> 2.0'
   pod 'ACPAnalytics', '~> 2.0'
   pod 'ACPMedia', '~> 2.0'
@@ -12,7 +13,7 @@ end
 
 target 'BitmovinAdobeAnalytics_Example' do
   use_frameworks!
-  platform :ios, '10.0'
+  platform :ios, '12.0'
   shared_pods
 
   pod 'GoogleAds-IMA-iOS-SDK', '3.12.1'
@@ -20,16 +21,16 @@ end
 
 target 'BitmovinAdobeAnalytics_TvOSExample' do
   use_frameworks!
-  platform :tvos, '10.0'
+  platform :tvos, '12.0'
 
   shared_pods
 end
 
 target 'BitmovinAdobeAnalytics_Tests' do
   use_frameworks!
-  platform :ios, '10.0'
+  platform :ios, '12.0'
   shared_pods
 
-  pod 'Quick', '~> 1.3.2'
-  pod 'Nimble', '~> 7.3.1'
+  pod 'Quick', '~> 4.0.0'
+  pod 'Nimble', '~> 9.2.0'
 end


### PR DESCRIPTION
### Problem
A new major version V3 of Bitmovin iOS SDK was release in April 2021. All new integrations need to use V3 SDK and all new feature requests also will be available only in V3 player SDK. So need to update the Bitmovin Adobe integration to use V3 SDK to allow existing and new customers to use this with V3 player SDK

### Solution
Upgrading Bitmovin Adobe integration to use V3 version of Bitmovin iOS player SDK

### Notes
- Changes to use V3 layer SDK API
- Adobe integration is functionally same as old version. No new feature or fix is added to the same.
- Playlist feature support is not added yet to Adobe integration
- This PR is without adding test cases and validated manually. Test cases did not exist before as well. Will try to add tests in a follow up PR.

### Checklist
- [x] I updated `README.md` file
- [ ] I added an update to `CHANGELOG.md` file
- [x] No test cases in project. I did manual validation.
