### PR TITLE
Resume pause tracking for VAST/VMAP Ads

### DIFF
--- a/Example/BitmovinAdobeAnalytics/ViewController.swift
+++ b/Example/BitmovinAdobeAnalytics/ViewController.swift
@@ -89,7 +89,7 @@ class ViewController: UIViewController {
 
     var adConfig: AdvertisingConfig {
         // swiftlint:disable:next line_length
-        let adTagVmap = "https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpremidpostpod&cmsid=496&vid=short_onecue&correlator="
+        let adTagVmap = "https://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&impl=s&gdfp_req=1&env=vp&output=vmap&unviewed_position_start=1&cust_params=deployment%3Ddevsite%26sample_ar%3Dpremidpostpodbumper&cmsid=496&vid=short_onecue&correlator="
 
         let adSource = AdSource(tag: URL(string: adTagVmap)!, ofType: .ima)
 

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 def shared_pods
   pod 'BitmovinAdobeAnalytics', path: '../'
-  pod 'BitmovinPlayer', '3.6.0'
+  pod 'BitmovinPlayer', '3.13.0'
   pod 'ACPCore', '~> 2.0'
   pod 'ACPAnalytics', '~> 2.0'
   pod 'ACPMedia', '~> 2.0'
@@ -16,7 +16,7 @@ target 'BitmovinAdobeAnalytics_Example' do
   platform :ios, '12.0'
   shared_pods
 
-  pod 'GoogleAds-IMA-iOS-SDK', '3.12.1'
+  pod 'GoogleAds-IMA-iOS-SDK', '3.14.5'
 end
 
 target 'BitmovinAdobeAnalytics_TvOSExample' do


### PR DESCRIPTION
**Issue**

For CSAI use case using VAST/VMAP Ads, Bitmovin iOS player SDK fires `Paused` event when playback transitions from main content to Ads. Then `Playing` event is fired when playback transitions back from Ad to main content.

Bitmovin's Adobe analytics integration follows these events and send them to analytics as trackPause() at beginning of Ad playback and trackPlay() at end of Ad playback. Due to this the session shows up as paused for the duration of Ads in Adobe analytics. 

**Fix**
- Check if Paused event was received earlier which is not resumed yet when AdStarted event is handled. If found, send trackPlay() to resume tracking.

**Tested Scenarios**
- Pre-roll, mid-roll playback for both VAST and VMAP Ad tags. Validated that `trackPlay()` is called for first AdStarted event after an AdBreak/Ad starts. Subsequent Ads in an AdBreak do not result in addition trackPlay() calls.
- User triggered pause during Ad playback. Validated that no additional `trackPlay()` called due to new logic.
- Pre-roll, mid-roll tested for both VAST and VMAP Ad tags with startOffset configuration.